### PR TITLE
Fiddly/styles

### DIFF
--- a/src/components/DetailedFeatures.jsx
+++ b/src/components/DetailedFeatures.jsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 const DetailedFeatures = ({ features }) => (
-    <ul className="flex flex-col gap-16 xl:gap-20 items-center py-28 md:px-12 lg:px-36 xl:px-46 2xl:px-64 mx-24 md:mx-36 xl:mx-64 text-gray-800">
+    <ul className="flex flex-col gap-16 xl:gap-20 items-center py-28 px-4  max-w-prose m-auto text-gray-800">
         {features.map((f, i) => {
             const innerClasses =
                 i % 2 === 0
@@ -23,7 +23,7 @@ const DetailedFeatures = ({ features }) => (
                         <h3 className="mt-2 xl:mt-0 font-semibold xl:font-normal text-center xl:text-left text-3xl xl:text-4xl">
                             {f.title}
                         </h3>
-                        <p className="mt-2 text-center xl:text-left">
+                        <p className="mt-2 max-w-prose xl:text-left">
                             {f.content}
                         </p>
                     </div>

--- a/src/components/Feature.jsx
+++ b/src/components/Feature.jsx
@@ -3,21 +3,21 @@ import * as React from "react";
 const Feature = ({ featureIcon, featureName, featureDescription, linksTo }) => {
     const content = (
         <>
-            <div className="flex items-center justify-center bg-gray-100 text-gray-800 rounded-full py-2 px-2 w-16 h-16 xl:w-14 xl:h-14 shadow-lg">
+            <div className="flex items-center justify-center bg-gray-100 text-gray-800 rounded-full py-2 px-4 w-16 h-16 xl:w-14 xl:h-14 shadow-lg">
                 {featureIcon}
             </div>
             <h3 className="mt-2 font-semibold text-center text-3xl xl:text-lg">
                 {featureName}
             </h3>
             {featureDescription && (
-                <p className="mt-2 text-center text-lg xl:text-sm">
+                <p className="mt-2 max-w-prose text-lg xl:text-sm">
                     {featureDescription}
                 </p>
             )}
         </>
     );
 
-    const wrapperClasses = "flex flex-col items-center";
+    const wrapperClasses = "flex flex-col items-center max-w-prose m-auto";
 
     return linksTo ? (
         <a href={linksTo} className={wrapperClasses}>

--- a/src/components/Feature.jsx
+++ b/src/components/Feature.jsx
@@ -10,14 +10,14 @@ const Feature = ({ featureIcon, featureName, featureDescription, linksTo }) => {
                 {featureName}
             </h3>
             {featureDescription && (
-                <p className="mt-2 max-w-prose text-lg xl:text-sm">
+                <p className="mt-2 max-w-prose text-lg xl:text-sm flex-1">
                     {featureDescription}
                 </p>
             )}
         </>
     );
 
-    const wrapperClasses = "flex flex-col items-center max-w-prose m-auto";
+    const wrapperClasses = "flex flex-col items-center max-w-prose m-auto h-full";
 
     return linksTo ? (
         <a href={linksTo} className={wrapperClasses}>

--- a/src/components/FeaturesRow.jsx
+++ b/src/components/FeaturesRow.jsx
@@ -3,7 +3,8 @@ import * as React from "react";
 const FeatureRow = ({ children }) => (
     <div
         id="features"
-        className="flex flex-col gap-12 xl:grid xl:grid-cols-3 xl:gap-x-20 mt-20 mx-20 md:mx-28 xl:mx-36"
+        className="flex flex-col gap-12 xl:grid xl:grid-cols-3 xl:gap-x-4 px-4 mt-20 m-auto"
+
     >
         {children}
     </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -9,7 +9,7 @@ const Footer = () => (
                 <a href="/" className="font-logo text-3xl">
                     NovelRT
                 </a>
-                <p className="text-gray-400 w-88">
+                <p className="text-gray-400 max-w-prose">
                     A cross-platform 2D game engine accompanied by a strong
                     toolset for visual novels.
                 </p>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -14,7 +14,7 @@ const Hero = ({ children, image, title, description }) => (
         >
             {title}
         </h1>
-        <h2 className="text-lg mx-16 xl:w-1/2 text-center">{description}</h2>
+        <h2 className="text-lg px-4 my-6 max-w-prose my-6 xl:w-1/2 ">{description}</h2>
 
         {children}
     </div>


### PR DESCRIPTION
Change styles to include some common styling best practices.

- long text should be left justified
- text should have a max-width based on readability standards
- text on mobile should not be too narrow and should not hit the sides of the screen
- cards should be of equal height when presented horizontally

Changes can be seen in two silent videos running polypane showing 3 different screen sizes.

[Original Styling Before Suggested Changes](https://youtu.be/R4ekOeqqgbA)

[With Fiddly Changes](https://youtu.be/Ny1T2F41i64)